### PR TITLE
23 canvas drawing doesnt work on ipad

### DIFF
--- a/backend/static/canvas_drawing.js
+++ b/backend/static/canvas_drawing.js
@@ -35,10 +35,6 @@ function getRandomInt(min, max) {
  * @param {CharacterDrawingControls} controls
  */
 const setupCanvasDrawing = (canvas, controls) => {
-    // Fix an issue that prevents canvas drawing on iPad
-    // https://github.com/playcanvas/editor/issues/160#issuecomment-1314064644
-    canvas.style['-webkit-user-select'] = 'none';
-
     let ctx = canvas.getContext("2d");
     let drawing_index = controls.symbolSet.value.length;
 


### PR DESCRIPTION
It wasn't working simply because we were only checking for mouse events, not touch events.
I took this as an opportunity to factor out the drawing functions (`penDown` and `drawLine`) from the input event handlers. The drawing functions now simply accept `x` and `y` arguments, which are generated by the event handlers.