### PR TITLE
whiteboard.mjs: capture primary pointer

### DIFF
--- a/backend/static/modules/whiteboard.mjs
+++ b/backend/static/modules/whiteboard.mjs
@@ -166,6 +166,8 @@ class Whiteboard extends HTMLElement {
     }
 
     #handlePointerDown(event) {
+        if (event.isPrimary)
+            event.target.setPointerCapture(event.pointerId);
         switch (this.#eventAction(event)) {
         case "erase":
             let ctx = this.#activeDrawingContext();
@@ -215,6 +217,8 @@ class Whiteboard extends HTMLElement {
     }
 
     #handlePointerUp(event) {
+        if (event.isPrimary)
+            event.target.releasePointerCapture(event.pointerId);
         switch (this.#eventAction(event)) {
         case "erase":
             let ctx = this.#activeDrawingContext();


### PR DESCRIPTION
This allows us to keep receiving pointer events even if the pointer leaves the browser window.
This means we can keep resizing going properly when the pointer strays onto the control bar.