### PR TITLE
only transcribe when state is stale + await execution

### DIFF
--- a/backend/static/modules/code-block.mjs
+++ b/backend/static/modules/code-block.mjs
@@ -128,10 +128,16 @@ class CodeBlock extends HTMLElement {
         this.#run.addEventListener("click", async () => {
             // Disable the run button until we finish executing to prevent double-clicks.
             this.#run.disabled = true;
-            await this.transcribeCodeBlockImage();
+
+            // Only transcribe when user has made changes to code block
+            if (this.getAttribute("state") == "stale"){
+                await this.transcribeCodeBlockImage();
+            }
+                
             // On run, we perform text recognition, so the block is no longer stale.
             this.setAttribute("state", "executed");
-            this.executeTranscribedCode();
+
+            await this.executeTranscribedCode();
 
             // Re-enable the run button now code has executed.
             this.#run.disabled = false;
@@ -273,13 +279,13 @@ class CodeBlock extends HTMLElement {
 
     }
 
-    executeTranscribedCode() {
+    async executeTranscribedCode() {
         // Put the execution language and code to be executed into FormData object
         const executeFormData = new FormData();
         executeFormData.append("language", this.getAttribute("language"));
         executeFormData.append("code", this.#text.textContent);
 
-        fetch("/execute/", {
+        return fetch("/execute/", {
             method: "POST",
             body: executeFormData,
             credentials: 'include',


### PR DESCRIPTION
Code block is only transcribed if state is stale.
Changed to call to executeTranscribedCode to now await for the output from the jupyter server, this prevents users re-running a code block before the output is received .