### PR TITLE
Language dropdown on toolbar

### DIFF
--- a/backend/templates/main_app.html
+++ b/backend/templates/main_app.html
@@ -8,7 +8,7 @@
   <body>
     <header class="spaced-bar tool-bar">
       <div class="spaced-bar">
-        <img id="language-logo" width="48px" height="48px" alt="APL Logo" src="https://raw.githubusercontent.com/abrudz/logos/refs/heads/main/apl/green.svg"/>
+        <img id="language-logo" width="48px" height="48px"/>
         <select id="default-language" name="default-language" title="Default Language">
           <option value="python3">Python</option>
           <option value="dyalog_apl">APL</option>


### PR DESCRIPTION
![Screenshot from 2025-04-04 11-19-27](https://github.com/user-attachments/assets/5c227592-3b66-460b-83e9-c386480b31de)

This is an essential feature that shouldn't be relegated to the settings menu.

I've also taken this opportunity to remove the default `src` on the language logo: we always set this programmatically anyway, and the old value was out of date.