### PR TITLE
code-block: toggle buttons for text and output

### DIFF
--- a/backend/static/code_block.css
+++ b/backend/static/code_block.css
@@ -100,3 +100,8 @@
     transform: rotate(45deg);
     margin: 5px;
 }
+
+.toggle-box {
+    display: flex;
+    align-items: start;
+}

--- a/backend/static/common.css
+++ b/backend/static/common.css
@@ -52,16 +52,20 @@ code {
     font-family: bqn386;
 }
 
-button, select {
+button, select, label:has(input[type="checkbox"].toggle-button) {
     background-color: var(--ui-background-color);
     border: 0.1rem solid var(--ui-border-color);
     border-radius: 0.25rem;
     padding: 0.25rem 0.5rem;
-    &:not([disabled]):hover {
-        background-color: var(--ui-focus-color);
-    }
+
     &.material-symbols-outlined {
         border-radius: 1rem;
+    }
+}
+
+button {
+    &:not([disabled]):hover {
+        background-color: var(--ui-focus-color);
     }
 }
 
@@ -159,4 +163,23 @@ dialog {
 /* mix-blend-mode: difference makes lambda show up against background */
 img[src$="lambda.svg"] {
     mix-blend-mode: difference;
+}
+
+/* Toggle Button-style checkboxes */
+input[type="checkbox"].toggle-button {
+    display: none;
+}
+
+/* TODO convert to button-based solution */
+label:has(input[type="checkbox"].toggle-button):hover {
+    background-color: var(--ui-focus-color);
+}
+
+label:has(input[type="checkbox"].toggle-button:checked) {
+    background-color: var(--ui-accent-color);
+    color: var(--default-background-color);
+
+    &:hover {
+        background-color: color-mix(in hsl, var(--ui-accent-color), white 10%) !important;
+    }
 }

--- a/backend/static/modules/code-block.mjs
+++ b/backend/static/modules/code-block.mjs
@@ -9,8 +9,6 @@ const code_block_template = `
   <button id="run" class="material-symbols-outlined">play_arrow</button>
   <span id="loader"></span>
   <span id="tick"></span>
-  <label class="material-symbols-outlined"><input id="show-output" name="show-output" type="checkbox"/>output</label>
-  <label class="material-symbols-outlined"><input id="show-text" name="show-text" type="checkbox"/>text_fields</label>
   <button id="language-switch">
     <img height="24" src="/static/logos/apl.svg" alt="APL"/>
   </button>
@@ -19,9 +17,15 @@ const code_block_template = `
 </div>
 </div>
 <div id="output-column">
-  <div contenteditable="true" id="text" class="ui-window clickable resizeable"></div>
+  <div class="toggle-box">
+    <label class="material-symbols-outlined clickable"><input id="show-text" name="show-text" type="checkbox" class="toggle-button"/>text_fields</label>
+    <div contenteditable="true" id="text" class="ui-window clickable resizeable"></div>
+  </div>
   <dialog id="predictions" class="ui-window clickable"></dialog>
-  <textarea id="output" class="ui-window clickable"></textarea>
+  <div class="toggle-box">
+    <label class="material-symbols-outlined clickable"><input id="show-output" name="show-output" type="checkbox" class="toggle-button"/>output</label>
+    <textarea id="output" class="ui-window clickable"></textarea>
+  </div>
 </div>
 `;
 
@@ -74,6 +78,8 @@ class CodeBlock extends HTMLElement {
     #controls;
     /** The tick icon */
     #tick;
+    /** The container for the entire output column */
+    #output_column;
 
     /** Icon showing the logo for this block's language. */
     #language_logo;
@@ -85,6 +91,7 @@ class CodeBlock extends HTMLElement {
         const shadowRoot = this.attachShadow({mode: 'open'});
         shadowRoot.innerHTML = code_block_template;
 
+        this.#output_column = shadowRoot.getElementById("output-column");
         this.#selection = shadowRoot.getElementById("selection");
         this.#text = shadowRoot.getElementById("text");
         this.#output = shadowRoot.getElementById("output");
@@ -447,10 +454,12 @@ class CodeBlock extends HTMLElement {
         // inactive tabs/pages, which also relies on visibility. TODO: Avoid this potential
         // interaction entirely.
         this.#controls.style.removeProperty("visibility");
+        this.#output_column.style.removeProperty("visibility");
     }
 
     #hideControls() {
         this.#controls.style.visibility = "hidden";
+        this.#output_column.style.visibility = "hidden";
     }
 
     #showOutput() {


### PR DESCRIPTION
![Screenshot from 2025-04-06 17-39-45](https://github.com/user-attachments/assets/bc9c2f2e-cd77-4a27-ba34-ad6d3539ce09)

The "buttons" are still `label>input[type=checkbox]` so dragging clicks don't register properly on Firefox (and Safari?), but the user doesn't need to press these buttons too often, and I can't be bothered to write a hacky workaround for it again.

This placement makes it clearer to the user what the text and output boxes are for