### PR TITLE
Compact toolbar

### DIFF
--- a/backend/static/common.css
+++ b/backend/static/common.css
@@ -122,6 +122,11 @@ dialog::backdrop {
     align-items: center;
 }
 
+.left-stack {
+    display: flex;
+    flex-direction: column;
+    align-items: start;
+}
 fieldset {
     border: var(--thin-border) solid var(--ui-border-color);
     border-radius: var(--thin-border);

--- a/backend/static/common.css
+++ b/backend/static/common.css
@@ -99,7 +99,7 @@ dialog::backdrop {
 
 
 .ui-group {
-    padding: 0.5rem;
+    padding: 0.25rem;
     border: var(--thin-border) solid var(--ui-border-color);
     border-radius: 3px;
 }

--- a/backend/static/main_app.css
+++ b/backend/static/main_app.css
@@ -47,3 +47,19 @@ main {
 #help-dialog h3{
     font-size: 100%;
 }
+
+input[type="range"] {
+    width: 7rem;
+}
+
+label:has(input#show-annotations:checked) {
+    & #annotations-off {
+        display: none;
+    }
+}
+
+label:has(input#show-annotations:not(:checked)) {
+    & #annotations-on {
+        display: none;
+    }
+}

--- a/backend/templates/main_app.html
+++ b/backend/templates/main_app.html
@@ -48,37 +48,33 @@
         </button>
       </radio-panel>
 
-      <div class="spaced-bar" style="gap: 1rem">
-        <div class="spaced-bar">
-          <label for="pen-width">
-            Pen Size
-          </label>
-          <input id="pen-width" name="pen-width" type="range" value="3" min="1" max="30"/>
-        </div>
-
-        <div class="spaced-bar">
-          <label for="eraser-width">
-            Eraser Size
-          </label>
-          <input id="eraser-width" name="eraser-width" type="range" value="20" min="5" max="30"/>
-        </div>
-
-        <div class="spaced-bar">
-          <label for="line-color" class="material-symbols-outlined">palette</label>
-          <input id="line-color" name="line-color" type="color" value="#ffffff"/>
-        </div>
-      </div>
-
-      <div class="spaced-bar" style="gap: 1rem">
-        <radio-panel id="layer">
-          <button value="code" disabled>Code</button>
-          <button value="annotations">Notes</button>
-        </radio-panel>
-        <label>
-          <input id="show-annotations" type="checkbox" checked/>
-          Show Notes
+      <div class="left-stack">
+        <label for="pen-width">
+          Pen Size
         </label>
+        <input id="pen-width" name="pen-width" type="range" value="3" min="1" max="30"/>
       </div>
+
+      <div class="left-stack">
+        <label for="eraser-width">
+          Eraser Size
+        </label>
+        <input id="eraser-width" name="eraser-width" type="range" value="20" min="5" max="30"/>
+      </div>
+
+      <div class="spaced-bar">
+        <label for="line-color" class="material-symbols-outlined">palette</label>
+        <input id="line-color" name="line-color" type="color" value="#ffffff"/>
+      </div>
+
+      <radio-panel id="layer">
+        <button value="code" disabled>Code</button>
+        <button value="annotations">Notes</button>
+      </radio-panel>
+      <label>
+        <input id="show-annotations" type="checkbox" checked/>
+        Show Notes
+      </label>
 
       <div>
         <button id="open-help">

--- a/backend/templates/main_app.html
+++ b/backend/templates/main_app.html
@@ -28,45 +28,60 @@
         </button>
       </div>
 
+      <div class="spaced-bar">
+        <button id="undo" title="Undo" class="material-symbols-outlined" disabled>undo</button>
+        <button id="redo" title="Redo" class="material-symbols-outlined" disabled>redo</button>
+      </div>
+
       <radio-panel id="tool">
-        <button value="pan" title="Pan" class="material-symbols-outlined">
-          drag_pan
-        </button>
-        <button value="select" class="material-symbols-outlined">
-          select
-        </button>
         <button value="write" class="material-symbols-outlined" disabled>
           edit
         </button>
         <button value="erase" class="material-symbols-outlined">
           ink_eraser
         </button>
+        <button value="select" class="material-symbols-outlined">
+          select
+        </button>
+        <button value="pan" title="Pan" class="material-symbols-outlined">
+          drag_pan
+        </button>
       </radio-panel>
 
-      <label>
-        Pen Width
-        <input id="pen-width" type="range" value="3" min="1" max="30"/>
-      </label>
-      <label>
-        Eraser Width
-        <input id="eraser-width" type="range" value="20" min="5" max="30"/>
-      </label>
+      <div class="spaced-bar" style="gap: 1rem">
+        <div style="display: flex; flex-direction: column">
+          <div class="spaced-bar">
+            <label for="pen-width">
+              Pen Size
+            </label>
+            <input id="pen-width" name="pen-width" type="range" value="3" min="1" max="30"/>
+          </div>
 
-      <input id="line-color" type="color" value="#ffffff"/>
+          <div class="spaced-bar">
+            <label for="eraser-width">
+              Eraser Size
+            </label>
+            <input id="eraser-width" name="eraser-width" type="range" value="20" min="5" max="30"/>
+          </div>
+        </div>
 
-      <div class="spaced-bar">
-        <button id="undo" title="Undo" class="material-symbols-outlined" disabled>undo</button>
-        <button id="redo" title="Redo" class="material-symbols-outlined" disabled>redo</button>
+        <div class="spaced-bar">
+          <label for="line-color" class="material-symbols-outlined">palette</label>
+          <input id="line-color" name="line-color" type="color" value="#ffffff"/>
+        </div>
       </div>
 
-      <label>
-        <input id="show-annotations" type="checkbox" checked/>
-        Show Annotations
-      </label>
-      <radio-panel id="layer">
-        <button value="code" disabled>Code</button>
-        <button value="annotations">Annotations</button>
-      </radio-panel>
+      <div class="spaced-bar" style="gap: 1rem">
+        <radio-panel id="layer">
+          <button value="code" disabled>Code</button>
+          <button value="annotations">Notes</button>
+        </radio-panel>
+        <label>
+          <input id="show-annotations" type="checkbox" checked/>
+          Show Notes
+        </label>
+      </div>
+
       <div>
         <button id="open-help">
           Help

--- a/backend/templates/main_app.html
+++ b/backend/templates/main_app.html
@@ -49,20 +49,18 @@
       </radio-panel>
 
       <div class="spaced-bar" style="gap: 1rem">
-        <div style="display: flex; flex-direction: column">
-          <div class="spaced-bar">
-            <label for="pen-width">
-              Pen Size
-            </label>
-            <input id="pen-width" name="pen-width" type="range" value="3" min="1" max="30"/>
-          </div>
+        <div class="spaced-bar">
+          <label for="pen-width">
+            Pen Size
+          </label>
+          <input id="pen-width" name="pen-width" type="range" value="3" min="1" max="30"/>
+        </div>
 
-          <div class="spaced-bar">
-            <label for="eraser-width">
-              Eraser Size
-            </label>
-            <input id="eraser-width" name="eraser-width" type="range" value="20" min="5" max="30"/>
-          </div>
+        <div class="spaced-bar">
+          <label for="eraser-width">
+            Eraser Size
+          </label>
+          <input id="eraser-width" name="eraser-width" type="range" value="20" min="5" max="30"/>
         </div>
 
         <div class="spaced-bar">


### PR DESCRIPTION
![Screenshot from 2025-04-07 15-15-37](https://github.com/user-attachments/assets/b9d57b33-25ed-4fa4-9a49-6b902e31ef9e)
- Shorter sliders, with titles stacked on top
- Change in user-facing terminology: s/annotation/note/, should be reflected in help menu, which needs a complete new set of screenshots, and a small update to the text, but let's make sure everything else is finalised first.