### PR TITLE
add whiteboard pre styling to preserve whitespace

### DIFF
--- a/backend/static/code_block.css
+++ b/backend/static/code_block.css
@@ -60,6 +60,11 @@
 #text {
     width: 200px;
     height: 40px;
+    white-space: pre;
+}
+
+#output{
+    white-space: pre;
 }
 
 .predicted-text-span:hover{


### PR DESCRIPTION
It was simply a styling issue, all data was passed correctly 

![image](https://github.com/user-attachments/assets/d16011e0-9f12-4a97-af32-8d6c66f4c88b)
