### PR TITLE
whiteboard.mjs: open shadowRoot

### DIFF
--- a/backend/static/modules/whiteboard.mjs
+++ b/backend/static/modules/whiteboard.mjs
@@ -383,7 +383,7 @@ class Whiteboard extends HTMLElement {
 
     constructor() {
         super();
-        const shadowRoot = this.attachShadow({mode: 'closed'});
+        const shadowRoot = this.attachShadow({mode: 'open'});
         shadowRoot.innerHTML = whiteboard_template;
         this.#container = shadowRoot.getElementById("container");
         this.#surface = shadowRoot.getElementById("surface");


### PR DESCRIPTION
This will be necessary for Playwright to work properly; thought I'd just get it onto dev quickly so I can try Playwright testing on the deployed application (handwriting server doesn't seem to work on my local setup still)