### PR TITLE
common.css: Grey out disabled toggle-button

### DIFF
--- a/backend/static/common.css
+++ b/backend/static/common.css
@@ -176,8 +176,13 @@ input[type="checkbox"].toggle-button {
 }
 
 /* TODO convert to button-based solution */
-label:has(input[type="checkbox"].toggle-button):hover {
+label:has(input[type="checkbox"].toggle-button:not(:disabled)):hover {
     background-color: var(--ui-focus-color);
+}
+
+/* TODO convert to button-based solution */
+label:has(input[type="checkbox"].toggle-button:disabled) {
+    color: grey;
 }
 
 label:has(input[type="checkbox"].toggle-button:checked) {


### PR DESCRIPTION
This is necessary because we disable the text representation toggle when a code block is stale, which could confuse the user if they click it and nothing happens.
![Screenshot from 2025-04-21 14-53-05](https://github.com/user-attachments/assets/445c5baa-7191-447b-ace4-34f63b50bed1)
